### PR TITLE
Fix: logout after page reload

### DIFF
--- a/project/src/services/token.ts
+++ b/project/src/services/token.ts
@@ -7,8 +7,8 @@ export const getToken = (): Token => {
   let token = '';
   try {
     if (
-      global.localStorage &&
-      typeof global.localStorage.getItem === 'function'
+      window.localStorage &&
+      typeof window.localStorage.getItem === 'function'
     ) {
       token = localStorage.getItem(LOCALSTORAGE_AUTH_TOKEN) || '';
     }
@@ -19,8 +19,8 @@ export const getToken = (): Token => {
 export const setToken = (token: Token): void => {
   try {
     if (
-      global.localStorage &&
-      typeof global.localStorage.setItem === 'function'
+      window.localStorage &&
+      typeof window.localStorage.setItem === 'function'
     ) {
       localStorage.setItem(LOCALSTORAGE_AUTH_TOKEN, token);
     }
@@ -30,8 +30,8 @@ export const setToken = (token: Token): void => {
 export const dropToken = (): void => {
   try {
     if (
-      global.localStorage &&
-      typeof global.localStorage.removeItem === 'function'
+      window.localStorage &&
+      typeof window.localStorage.removeItem === 'function'
     ) {
       localStorage.removeItem(LOCALSTORAGE_AUTH_TOKEN);
     }

--- a/project/src/services/token.ts
+++ b/project/src/services/token.ts
@@ -3,11 +3,14 @@ const LOCALSTORAGE_AUTH_TOKEN = 'guess-melody-auth-token';
 
 export type Token = string;
 
+const isLocalStorageAvailable = (): boolean =>
+  typeof window !== 'undefined' && !!window.localStorage;
+
 export const getToken = (): Token => {
   let token = '';
   try {
     if (
-      window.localStorage &&
+      isLocalStorageAvailable() &&
       typeof window.localStorage.getItem === 'function'
     ) {
       token = localStorage.getItem(LOCALSTORAGE_AUTH_TOKEN) || '';
@@ -19,7 +22,7 @@ export const getToken = (): Token => {
 export const setToken = (token: Token): void => {
   try {
     if (
-      window.localStorage &&
+      isLocalStorageAvailable() &&
       typeof window.localStorage.setItem === 'function'
     ) {
       localStorage.setItem(LOCALSTORAGE_AUTH_TOKEN, token);
@@ -30,7 +33,7 @@ export const setToken = (token: Token): void => {
 export const dropToken = (): void => {
   try {
     if (
-      window.localStorage &&
+      isLocalStorageAvailable() &&
       typeof window.localStorage.removeItem === 'function'
     ) {
       localStorage.removeItem(LOCALSTORAGE_AUTH_TOKEN);

--- a/project/src/services/token.ts
+++ b/project/src/services/token.ts
@@ -1,22 +1,22 @@
-/* eslint no-empty: ["error", { "allowEmptyCatch": true }] */
 const LOCALSTORAGE_AUTH_TOKEN = 'guess-melody-auth-token';
 
-export type Token = string;
+export type Token = string | undefined;
 
 const isLocalStorageAvailable = (): boolean =>
   typeof window !== 'undefined' && !!window.localStorage;
 
 export const getToken = (): Token => {
-  let token = '';
   try {
     if (
       isLocalStorageAvailable() &&
       typeof window.localStorage.getItem === 'function'
     ) {
-      token = localStorage.getItem(LOCALSTORAGE_AUTH_TOKEN) || '';
+      const token = localStorage.getItem(LOCALSTORAGE_AUTH_TOKEN);
+      return token ? JSON.parse(token) : undefined;
     }
-  } catch {}
-  return token;
+  } catch {
+    return undefined;
+  }
 };
 
 export const setToken = (token: Token): void => {
@@ -25,8 +25,9 @@ export const setToken = (token: Token): void => {
       isLocalStorageAvailable() &&
       typeof window.localStorage.setItem === 'function'
     ) {
-      localStorage.setItem(LOCALSTORAGE_AUTH_TOKEN, token);
+      localStorage.setItem(LOCALSTORAGE_AUTH_TOKEN, JSON.stringify(token));
     }
+    // eslint-disable-next-line no-empty
   } catch {}
 };
 
@@ -38,5 +39,6 @@ export const dropToken = (): void => {
     ) {
       localStorage.removeItem(LOCALSTORAGE_AUTH_TOKEN);
     }
+    // eslint-disable-next-line no-empty
   } catch {}
 };


### PR DESCRIPTION
**Pull Request Overview**

This PR replaces checks against `global.localStorage` with `window.localStorage` in the token service to address logout behavior after a page reload.

Swapped `global.localStorage `references for `window.localStorage` in `getToken`, `setToken`, and `dropToken`.