### PR TITLE
Feat: update lose page

### DIFF
--- a/project/src/components/error-screen/error-screen.css
+++ b/project/src/components/error-screen/error-screen.css
@@ -1,5 +1,6 @@
 .error-screen {
   gap: 3rem;
+  align-items: center;
 }
 
 .error-screen__text {

--- a/project/src/components/layout/layout.css
+++ b/project/src/components/layout/layout.css
@@ -4,7 +4,6 @@
 }
 
 .game__screen {
-  align-items: center;
   color: var(--text-color);
   display: flex;
   flex-direction: column;

--- a/project/src/pages/result/lose/index.tsx
+++ b/project/src/pages/result/lose/index.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
-import Logo from '@components/logo/logo';
+import Layout from '@components/layout';
 import { useAppDispatch } from '@hooks/use-store';
 import { AppRoute } from '@settings';
 import { resetGame } from '@store/slices/game-process/game-process';
+
+import './lose.css';
 
 const LoseScreen: React.FC = () => {
   const navigate = useNavigate();
@@ -15,19 +17,20 @@ const LoseScreen: React.FC = () => {
   };
 
   return (
-    <section className="result">
-      <div className="result__logo">
-        <Logo />
-      </div>
-      <h2 className="result__title">What a pity!</h2>
+    <Layout className="result">
+      <h2 className="main__title">What a pity!</h2>
       <p className="result__total result__total--fail">
         You&apos;ve run out of attempts. Never mind, you&apos;ll be lucky next
         time!
       </p>
-      <button className="replay" type="button" onClick={onReplyClick}>
+      <button
+        className="replay result__button"
+        type="button"
+        onClick={onReplyClick}
+      >
         Try again
       </button>
-    </section>
+    </Layout>
   );
 };
 

--- a/project/src/pages/result/lose/index.tsx
+++ b/project/src/pages/result/lose/index.tsx
@@ -11,7 +11,7 @@ const LoseScreen: React.FC = () => {
   const navigate = useNavigate();
   const dispatch = useAppDispatch();
 
-  const onReplyClick = () => {
+  const onReplayClick = () => {
     dispatch(resetGame());
     navigate(AppRoute.Game);
   };
@@ -19,14 +19,14 @@ const LoseScreen: React.FC = () => {
   return (
     <Layout className="result">
       <h2 className="main__title">What a pity!</h2>
-      <p className="result__total result__total--fail">
+      <p className="result__total">
         You&apos;ve run out of attempts. Never mind, you&apos;ll be lucky next
         time!
       </p>
       <button
         className="replay result__button"
         type="button"
-        onClick={onReplyClick}
+        onClick={onReplayClick}
       >
         Try again
       </button>

--- a/project/src/pages/result/lose/lose.css
+++ b/project/src/pages/result/lose/lose.css
@@ -1,0 +1,9 @@
+.result__total {
+  font-size: 1.25rem;
+  margin: 15rem 0 0;
+}
+
+.result__button {
+  font-size: 1.25rem;
+  margin: auto 0 0;
+}

--- a/project/src/pages/result/lose/lose.test.tsx
+++ b/project/src/pages/result/lose/lose.test.tsx
@@ -1,0 +1,152 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import { MemoryRouter } from 'react-router-dom';
+import { AppRoute } from '@settings';
+import { createMockStore } from '@test-utils/mock-store';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
+
+import LoseScreen from './index';
+
+// Mock the navigate function
+const mockNavigate = vi.fn();
+
+// Mock react-router-dom
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+describe('LoseScreen Component', () => {
+  const renderWithProvider = (storeState = {}) => {
+    const store = createMockStore({
+      GAME: {
+        mistakes: 3,
+        step: 5,
+        ...storeState,
+      },
+    });
+
+    return render(
+      <Provider store={store}>
+        <MemoryRouter>
+          <LoseScreen />
+        </MemoryRouter>
+      </Provider>,
+    );
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('Component Rendering', () => {
+    it('should render lose screen with correct title and description', () => {
+      renderWithProvider();
+
+      expect(
+        screen.getByRole('heading', { name: 'What a pity!', level: 2 }),
+      ).toBeVisible();
+      expect(screen.getByText(/you've run out of attempts/i)).toBeVisible();
+      expect(
+        screen.getByText(/never mind, you'll be lucky next time!/i),
+      ).toBeVisible();
+    });
+
+    it('should render try again button', () => {
+      renderWithProvider();
+
+      const tryAgainButton = screen.getByRole('button', { name: /try again/i });
+      expect(tryAgainButton).toBeVisible();
+      expect(tryAgainButton).toHaveAttribute('type', 'button');
+    });
+  });
+
+  describe('User Interactions', () => {
+    it('should reset game and navigate to game screen when try again button is clicked', async () => {
+      const user = userEvent.setup();
+      const customStore = createMockStore({
+        GAME: {
+          mistakes: 3,
+          step: 5,
+        },
+      });
+
+      render(
+        <Provider store={customStore}>
+          <MemoryRouter>
+            <LoseScreen />
+          </MemoryRouter>
+        </Provider>,
+      );
+
+      const tryAgainButton = screen.getByRole('button', { name: /try again/i });
+      await user.click(tryAgainButton);
+
+      // Verify the effect: game state should be reset to initial values
+      const state = customStore.getState();
+      expect(state.GAME.mistakes).toBe(0);
+      expect(state.GAME.step).toBe(0); // FIRST_GAME_STEP from settings
+
+      // Verify navigation
+      expect(mockNavigate).toHaveBeenCalledTimes(1);
+      expect(mockNavigate).toHaveBeenCalledWith(AppRoute.Game);
+    });
+  });
+
+  describe('Layout Integration', () => {
+    it('should render within Layout component with correct className', () => {
+      const { container } = renderWithProvider();
+
+      const layoutSection = container.querySelector('section.game');
+      expect(layoutSection).toBeInTheDocument();
+
+      const mainElement = container.querySelector('.game__screen.result');
+      expect(mainElement).toBeInTheDocument();
+    });
+
+    it('should render logo in header by default', () => {
+      const { container } = renderWithProvider();
+
+      const header = container.querySelector('.game__header');
+      expect(header).toBeInTheDocument();
+
+      const logo = container.querySelector('.game__logo');
+      expect(logo).toBeInTheDocument();
+    });
+  });
+
+  describe('Accessibility', () => {
+    it('should have proper heading structure', () => {
+      renderWithProvider();
+
+      const heading = screen.getByRole('heading', {
+        name: 'What a pity!',
+        level: 2,
+      });
+      expect(heading).toHaveClass('main__title');
+    });
+
+    it('should have accessible button', () => {
+      renderWithProvider();
+
+      const button = screen.getByRole('button', { name: /try again/i });
+      expect(button).toBeVisible();
+      expect(button).toBeEnabled();
+    });
+
+    it('should have proper text content for screen readers', () => {
+      renderWithProvider();
+
+      expect(screen.getByText('What a pity!')).toBeVisible();
+      expect(screen.getByText(/you've run out of attempts/i)).toBeVisible();
+      expect(
+        screen.getByText(/never mind, you'll be lucky next time!/i),
+      ).toBeVisible();
+    });
+  });
+});

--- a/project/src/pages/result/win/index.tsx
+++ b/project/src/pages/result/win/index.tsx
@@ -18,7 +18,7 @@ const WinScreen: React.FC = () => {
   const questions = useAppSelector(selectQuestions);
   const authorizationStatus = useAppSelector(selectAuthorizationStatus);
 
-  const onReplyClick = () => {
+  const onReplayClick = () => {
     dispatch(resetGame());
     navigate(AppRoute.Game);
   };
@@ -47,7 +47,7 @@ const WinScreen: React.FC = () => {
         You answered {questions.length - mistakesCount} questions correctly and
         made {mistakesCount} {mistakesCount === 1 ? 'mistake' : 'mistakes'}
       </p>
-      <button className="replay" onClick={onReplyClick} type="button">
+      <button className="replay" onClick={onReplayClick} type="button">
         Play again
       </button>
     </section>


### PR DESCRIPTION
**Pull Request Overview**

This PR refactors the Lose result page to use the shared Layout component, adds dedicated CSS styling, and introduces a comprehensive test suite for the LoseScreen.

* Refactored LoseScreen to wrap content with Layout and removed direct Logo usage
* Added` lose.css` to style the result text and button
* Created `lose.test.tsx` to cover rendering, user interactions, layout integration, and accessibility