### PR TITLE
Fix: login screen: replay button doesn't reset the game

### DIFF
--- a/project/src/components/app/app.tsx
+++ b/project/src/components/app/app.tsx
@@ -1,31 +1,27 @@
 import React, { Suspense } from 'react';
 import { Route, Routes } from 'react-router-dom';
-import { useAppSelector } from '@hooks/use-store';
 import { AppRoute } from '@settings';
-import { selectAuthorizationStatus } from '@store/slices/user/user';
 
 import Loader from '../loader';
 
 const GameScreen = React.lazy(() => import('@pages/game'));
-const Login = React.lazy(() => import('@pages/login'));
+const LoginScreen = React.lazy(() => import('@pages/login'));
 const LoseScreen = React.lazy(() => import('@pages/result/lose'));
-const NotFoundPage = React.lazy(() => import('@pages/not-found'));
+const NotFoundScreen = React.lazy(() => import('@pages/not-found'));
 const PrivateRoute = React.lazy(() => import('@components/private-route'));
 const WelcomeScreen = React.lazy(() => import('@pages/welcome-screen'));
 const WinScreen = React.lazy(() => import('@pages/result/win'));
 
 const App: React.FC = () => {
-  const authorizationStatus = useAppSelector(selectAuthorizationStatus);
-
   return (
     <Suspense fallback={<Loader />}>
       <Routes>
-        <Route path={AppRoute.Root} key="root" element={<WelcomeScreen />} />,
-        <Route path={AppRoute.Login} key="login" element={<Login />} />,
+        <Route path={AppRoute.Root} key="root" element={<WelcomeScreen />} />
+        <Route path={AppRoute.Login} key="login" element={<LoginScreen />} />
         <Route
           path={AppRoute.Result}
           element={
-            <PrivateRoute authorizationStatus={authorizationStatus}>
+            <PrivateRoute>
               <WinScreen />
             </PrivateRoute>
           }
@@ -36,7 +32,7 @@ const App: React.FC = () => {
           element={<LoseScreen />}
         />
         <Route path={AppRoute.Game} key="game" element={<GameScreen />} />
-        <Route path="*" key="not-found" element={<NotFoundPage />} />
+        <Route path="*" key="not-found" element={<NotFoundScreen />} />
       </Routes>
     </Suspense>
   );

--- a/project/src/components/private-route/index.tsx
+++ b/project/src/components/private-route/index.tsx
@@ -1,20 +1,21 @@
 import React from 'react';
 import { Navigate } from 'react-router-dom';
+import { useAppSelector } from '@hooks/use-store';
 import { AppRoute, AuthorizationStatus } from '@settings';
+import { selectAuthorizationStatus } from '@store/slices/user/user';
 
 type PrivateRouteProps = {
-  authorizationStatus: AuthorizationStatus;
   children: JSX.Element;
 };
 
-const PrivateRoute: React.FC<PrivateRouteProps> = ({
-  authorizationStatus,
-  children,
-}) =>
-  authorizationStatus === AuthorizationStatus.Auth ? (
+const PrivateRoute: React.FC<PrivateRouteProps> = ({ children }) => {
+  const authorizationStatus = useAppSelector(selectAuthorizationStatus);
+
+  return authorizationStatus === AuthorizationStatus.Auth ? (
     children
   ) : (
     <Navigate to={AppRoute.Login} />
   );
+};
 
 export default PrivateRoute;

--- a/project/src/pages/login/index.tsx
+++ b/project/src/pages/login/index.tsx
@@ -3,14 +3,15 @@ import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import Layout from '@components/layout';
 import LoginForm from '@components/login-form';
-import { useAppSelector } from '@hooks/use-store';
+import { useAppDispatch, useAppSelector } from '@hooks/use-store';
 import { AppRoute } from '@settings';
 import { selectQuestions } from '@store/slices/data/data';
-import { selectStep } from '@store/slices/game-process/game-process';
+import { resetGame, selectStep } from '@store/slices/game-process/game-process';
 import { selectUserEmail } from '@store/slices/user/user';
 
-const Login: React.FC = () => {
+const LoginScreen: React.FC = () => {
   const navigate = useNavigate();
+  const dispatch = useAppDispatch();
   const email = useAppSelector(selectUserEmail);
   const questions = useAppSelector(selectQuestions);
   const step = useAppSelector(selectStep);
@@ -23,6 +24,11 @@ const Login: React.FC = () => {
     }
   }, [step, email, navigate, questions.length]);
 
+  const onReplayClick = () => {
+    dispatch(resetGame());
+    navigate(AppRoute.Game);
+  };
+
   return (
     <Layout>
       <section className="login">
@@ -34,11 +40,7 @@ const Login: React.FC = () => {
 
         <LoginForm />
 
-        <button
-          className="replay"
-          onClick={() => navigate(AppRoute.Game)}
-          type="button"
-        >
+        <button className="replay" onClick={onReplayClick} type="button">
           Play again
         </button>
       </section>
@@ -46,4 +48,4 @@ const Login: React.FC = () => {
   );
 };
 
-export default Login;
+export default LoginScreen;

--- a/project/src/pages/login/login.test.tsx
+++ b/project/src/pages/login/login.test.tsx
@@ -6,7 +6,7 @@ import { createMockStore } from '@test-utils/mock-store';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-import Login from './index';
+import LoginScreen from './index';
 
 // Mock the navigate function
 const mockNavigate = vi.fn();
@@ -22,15 +22,20 @@ vi.mock('react-router-dom', async () => {
 
 describe('Login Page', () => {
   const renderLogin = (storeState = {}) => {
-    const store = createMockStore(storeState);
+    const store = createMockStore({
+      ...storeState,
+    });
 
-    return render(
-      <Provider store={store}>
-        <MemoryRouter>
-          <Login />
-        </MemoryRouter>
-      </Provider>,
-    );
+    return {
+      store,
+      ...render(
+        <Provider store={store}>
+          <MemoryRouter>
+            <LoginScreen />
+          </MemoryRouter>
+        </Provider>,
+      ),
+    };
   };
 
   beforeEach(() => {
@@ -52,39 +57,145 @@ describe('Login Page', () => {
       expect(screen.getByRole('button', { name: /play again/i })).toBeVisible();
     });
 
-    it('should handle play again button click', async () => {
-      const user = userEvent.setup();
+    it('should have correct attributes on play again button', () => {
       renderLogin();
+
+      const playAgainButton = screen.getByRole('button', {
+        name: /play again/i,
+      });
+
+      expect(playAgainButton).toHaveAttribute('type', 'button');
+      expect(playAgainButton).toHaveClass('replay');
+    });
+  });
+
+  describe('onReplayClick functionality', () => {
+    it('should reset game state and navigate to game when play again is clicked', async () => {
+      const user = userEvent.setup();
+      const { store } = renderLogin({
+        GAME: {
+          mistakes: 5,
+          step: 3,
+        },
+      });
+
+      const playAgainButton = screen.getByRole('button', {
+        name: /play again/i,
+      });
+
+      // Verify initial state
+      expect(store.getState().GAME.mistakes).toBe(5);
+      expect(store.getState().GAME.step).toBe(3);
+
+      await user.click(playAgainButton);
+
+      // Check that navigation was called with correct route
+      expect(mockNavigate).toHaveBeenCalledWith(AppRoute.Game);
+      expect(mockNavigate).toHaveBeenCalledTimes(1);
+
+      // Check that the game state was completely reset
+      const state = store.getState();
+      expect(state.GAME.mistakes).toBe(0);
+      expect(state.GAME.step).toBe(0);
+    });
+
+    it('should work correctly when game state is already at initial values', async () => {
+      const user = userEvent.setup();
+      const { store } = renderLogin({
+        GAME: {
+          mistakes: 0,
+          step: 0,
+        },
+      });
+
+      const playAgainButton = screen.getByRole('button', {
+        name: /play again/i,
+      });
+
+      await user.click(playAgainButton);
+
+      // Check that navigation was called
+      expect(mockNavigate).toHaveBeenCalledWith(AppRoute.Game);
+
+      // Check that the game state remains at initial values
+      const state = store.getState();
+      expect(state.GAME.mistakes).toBe(0);
+      expect(state.GAME.step).toBe(0);
+    });
+
+    it('should reset game state when play again button is clicked', async () => {
+      const user = userEvent.setup();
+      const { store } = renderLogin({
+        GAME: {
+          mistakes: 3,
+          step: 2,
+        },
+      });
 
       const playAgainButton = screen.getByRole('button', {
         name: /play again/i,
       });
       await user.click(playAgainButton);
 
+      // Verify the side effects of resetGame action: state was reset
+      const state = store.getState();
+      expect(state.GAME.mistakes).toBe(0);
+      expect(state.GAME.step).toBe(0);
+
+      // Verify navigation was called
       expect(mockNavigate).toHaveBeenCalledWith(AppRoute.Game);
     });
+
+    it('should handle multiple rapid clicks correctly', async () => {
+      const user = userEvent.setup();
+      const { store } = renderLogin({
+        GAME: {
+          mistakes: 2,
+          step: 1,
+        },
+      });
+
+      const playAgainButton = screen.getByRole('button', {
+        name: /play again/i,
+      });
+
+      // Click multiple times rapidly
+      await user.click(playAgainButton);
+      await user.click(playAgainButton);
+
+      // Navigation should be called multiple times
+      expect(mockNavigate).toHaveBeenCalledWith(AppRoute.Game);
+      expect(mockNavigate).toHaveBeenCalledTimes(2);
+
+      // State should still be reset correctly
+      const state = store.getState();
+      expect(state.GAME.mistakes).toBe(0);
+      expect(state.GAME.step).toBe(0);
+    });
   });
 
-  it('should navigate to result page if step equals questions length', () => {
-    renderLogin({
-      DATA: {
-        questions: Array(5).fill({}), // Mock 5 questions
-      },
-      GAME: {
-        step: 5, // Step equals questions length
-      },
+  describe('Navigation effects', () => {
+    it('should navigate to result page if step equals questions length', () => {
+      renderLogin({
+        DATA: {
+          questions: Array(5).fill({}),
+        },
+        GAME: {
+          step: 5,
+        },
+      });
+
+      expect(mockNavigate).toHaveBeenCalledWith(AppRoute.Result);
     });
 
-    expect(mockNavigate).toHaveBeenCalledWith(AppRoute.Result);
-  });
+    it('should navigate to root page if user email is present', () => {
+      renderLogin({
+        USER: {
+          email: 'test@mail.com',
+        },
+      });
 
-  it('should navigate to root page if user email is present', () => {
-    renderLogin({
-      USER: {
-        email: 'test@mail.com',
-      },
+      expect(mockNavigate).toHaveBeenCalledWith(AppRoute.Root);
     });
-
-    expect(mockNavigate).toHaveBeenCalledWith(AppRoute.Root);
   });
 });

--- a/project/src/types/global.d.ts
+++ b/project/src/types/global.d.ts
@@ -1,0 +1,7 @@
+import type { VitestUtils } from 'vitest';
+
+declare global {
+  var vi: VitestUtils;
+}
+
+export {};

--- a/project/vitest.setup.ts
+++ b/project/vitest.setup.ts
@@ -1,6 +1,10 @@
 import { webcrypto } from 'crypto';
+import { vi } from 'vitest';
 
 import '@testing-library/jest-dom/vitest';
+
+// Make vi globally available
+global.vi = vi;
 
 if (!global.crypto) {
   global.crypto = webcrypto as Crypto;


### PR DESCRIPTION
**Pull Request Overview**

This PR ensures the replay button on the login screen fully resets game state and adds corresponding tests, while renaming and wiring through the updated component names.

* Expose vi globally in Vitest setup
* Rename Login → LoginScreen, implement onReplayClick to dispatch resetGame and navigate
* Expand tests to cover replay behavior and navigation
* Update PrivateRoute to read auth status from store
* Adjust App routes to use renamed screens